### PR TITLE
Fix sql migrations scripts

### DIFF
--- a/files/sql/db.sql
+++ b/files/sql/db.sql
@@ -6,7 +6,7 @@ CREATE TABLE `users` (
   `drive_token` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `email` (`email`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `links` (
   `id` int unsigned NOT NULL AUTO_INCREMENT,
@@ -20,4 +20,4 @@ CREATE TABLE `links` (
   UNIQUE KEY `slug` (`slug`),
   KEY `links_user_id_users_id_foreign` (`user_id`),
   CONSTRAINT `links_user_id_users_id_foreign` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/files/sql/migration_20190904.sql
+++ b/files/sql/migration_20190904.sql
@@ -9,7 +9,7 @@ CREATE TABLE `user_storage_credentials` (
   UNIQUE KEY `user_provider_unique` (`user_id`, `provider_id`),
   KEY `usc_user_id_users_id_foreign` (`user_id`),
   CONSTRAINT `usc_user_id_users_id_foreign` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 ALTER TABLE `links`
 ADD `user_storage_credential_id` int(10) unsigned NULL,

--- a/files/sql/migration_20210402.sql
+++ b/files/sql/migration_20210402.sql
@@ -1,0 +1,1 @@
+ALTER TABLE bcc_drophere.users ADD password varchar(80) NULL;


### PR DESCRIPTION
Missing semicolons might create errors on some clients. The 'password' column on the 'users' table doesn't exist in the migration scripts.