### PR TITLE
Return an error when uploading if the link owner's dropbox token doesn't have the required scope.

### DIFF
--- a/infrastructure/storageprovider/dropbox.go
+++ b/infrastructure/storageprovider/dropbox.go
@@ -162,11 +162,11 @@ func (d *dropbox) mapToDropboxError(byteResponse *[]byte, httpStatusCode int) dr
 }
 
 func (d *dropbox) mapToRegularError(dropboxError *dropboxError) error {
-	if dropboxError.HttpCode == 400 {
+	if dropboxError.HttpCode == http.StatusBadRequest {
 		if strings.Contains(dropboxError.Message, "files.content.write") {
 			return errNotEnoughScope
 		}
-	} else if dropboxError.HttpCode == 401 {
+	} else if dropboxError.HttpCode == http.StatusUnauthorized {
 		if dropboxError.Json.ErrorStructured[".tag"].(string) == "missing_scope" && dropboxError.Json.ErrorStructured["required_scope"].(string) == "files.content.write" {
 			return errNotEnoughScope
 		}

--- a/infrastructure/storageprovider/dropbox.go
+++ b/infrastructure/storageprovider/dropbox.go
@@ -100,7 +100,7 @@ func (d *dropbox) Upload(cred domain.StorageProviderCredential, file io.Reader, 
 		return err
 	}
 
-	if res.StatusCode != 200 {
+	if res.StatusCode != http.StatusOK {
 		byteRes, _ := io.ReadAll(res.Body)
 		strRes := string(byteRes)
 		if strings.Contains(strRes, "files.content.write") {

--- a/infrastructure/storageprovider/dropbox.go
+++ b/infrastructure/storageprovider/dropbox.go
@@ -114,11 +114,7 @@ func (d *dropbox) Upload(cred domain.StorageProviderCredential, file io.Reader, 
 
 	if res.StatusCode != http.StatusOK {
 		dropboxError, err := d.mapToDropboxError(res.Body, res.StatusCode)
-		if err != nil {
-			return err
-		}
-
-		res.Body.Close()
+		defer res.Body.Close()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
A link owner must have at least the `files.content.write` scope to upload files.